### PR TITLE
Sea-level picking - collsision shape from corrected nodes

### DIFF
--- a/src/geom/godot_util.rs
+++ b/src/geom/godot_util.rs
@@ -3,17 +3,18 @@ use gdnative::core_types::{Int32Array, Vector3Array};
 use gdnative::prelude::*;
 
 use crate::geom::util::calc_normals;
+use crate::NodeData;
 
 pub fn to_collision_shape(
-    vertices: &[Vector3],
+    nodes: &[NodeData],
     faces: &[(usize, usize, usize)],
 ) -> Ref<ConcavePolygonShape, Unique> {
     let mut coll_faces = Vector3Array::new();
 
     for face in faces {
-        coll_faces.push(vertices[face.0]);
-        coll_faces.push(vertices[face.1]);
-        coll_faces.push(vertices[face.2]);
+        coll_faces.push(nodes[face.0].position);
+        coll_faces.push(nodes[face.1].position);
+        coll_faces.push(nodes[face.2].position);
     }
 
     let shape = ConcavePolygonShape::new();

--- a/src/geom/planet/generator.rs
+++ b/src/geom/planet/generator.rs
@@ -145,7 +145,7 @@ impl PlanetGenerator {
         let colors = self.generate_colors(&data.nodes);
 
         let mesh = to_mesh(&data.vertices, &data.faces, Some(colors));
-        let shape = to_collision_shape(&data.vertices, &data.faces);
+        let shape = to_collision_shape(&data.nodes, &data.faces);
 
         let arr = VariantArray::new();
         arr.push(data.emplace());
@@ -192,7 +192,7 @@ impl PlanetGenerator {
         let data = PlanetData::new(props, nodes, vertices, neighbors, faces);
 
         let mesh = to_mesh(&data.vertices, &data.faces, Some(colors));
-        let shape = to_collision_shape(&data.vertices, &data.faces);
+        let shape = to_collision_shape(&data.nodes, &data.faces);
 
         let arr = VariantArray::new();
         arr.push(data.emplace());


### PR DESCRIPTION
The collision shape now follows sea level instead of the ocean floor.