### PR TITLE
Elevation-dependent ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Land use "Irrigated crops"; allows cities in deserts
 * Animated textures to visualize traffic on roads
 * A different animated texture for sea lines
+* Display elevation in land use info
+* Elevation-dependent range of defenses
 
 ### Changed
 

--- a/scenes/gui/controls/land_use_info.tscn
+++ b/scenes/gui/controls/land_use_info.tscn
@@ -15,21 +15,30 @@ margin_right = 192.0
 margin_bottom = 16.0
 
 [node name="LandUse" type="Label" parent="HBoxContainer"]
-margin_right = 94.0
+margin_right = 148.0
 margin_bottom = 16.0
 size_flags_horizontal = 3
 text = "Land use"
+clip_text = true
 
-[node name="Resources" type="Label" parent="HBoxContainer"]
-margin_left = 98.0
+[node name="Elevation" type="Label" parent="HBoxContainer"]
+margin_left = 152.0
 margin_right = 192.0
 margin_bottom = 16.0
+text = "1000m"
+align = 2
+
+[node name="Resources" type="Label" parent="."]
+margin_top = 20.0
+margin_right = 192.0
+margin_bottom = 36.0
 size_flags_horizontal = 3
+size_flags_vertical = 0
 text = "Resources"
 
 [node name="Entries" type="HBoxContainer" parent="."]
-margin_top = 20.0
+margin_top = 40.0
 margin_right = 192.0
-margin_bottom = 100.0
+margin_bottom = 120.0
 grow_vertical = 0
 rect_min_size = Vector2( 0, 80 )

--- a/scripts/constants/consts.gd
+++ b/scripts/constants/consts.gd
@@ -2,6 +2,8 @@ class_name Consts
 
 const DEFAULT_VIEWPORT_HEIGHT: int = 720
 
+const ELEVATION_SCALE: int = 2500
+
 const INITIAL_BUDGET: int = 350
 
 const TRANSPORT_COST_1000: int = 25
@@ -37,3 +39,7 @@ const LAYER_RESOURCES: int = 4
 const LAYER_CITY_RANGES: int = 5
 const LAYER_DEFENSE_RANGES: int = 6
 const LAYER_EVENTS: int = 7
+
+
+static func elevation(ele: float, max_ele: float) -> int:
+	return int(round(ele * max_ele * ELEVATION_SCALE))

--- a/scripts/constants/facilities.gd
+++ b/scripts/constants/facilities.gd
@@ -120,7 +120,14 @@ class FacilityFunctions:
 	
 	
 	func air_defense_range(planet_data, node, radius) -> int:
+		var ele_max = planet_data.get_max_elevation()
 		var nd = planet_data.get_node(node)
-		var ele = max(nd.elevation, 0)
-		return int(floor(float(radius) * (1.0 + ele)))
+		var ele = Consts.elevation(nd.elevation, ele_max)
+		
+		if ele < 1000:
+			return radius
+		elif ele < 2000:
+			return int(round(radius * 1.25))
+		else:
+			return int(round(radius * 1.5))
 

--- a/scripts/constants/facilities.gd
+++ b/scripts/constants/facilities.gd
@@ -41,6 +41,13 @@ const FACILITY_RADIUS = {
 #	FAC_MISSILE_BASE: 0,
 }
 
+const FACILITY_RADIUS_FUNC = {
+	FAC_CITY: "constant_range",
+	FAC_PORT: "constant_range",
+	FAC_AIR_DEFENSE: "constant_range",
+#	FAC_MISSILE_BASE: "constant_range",
+}
+
 const FACILITY_COSTS = {
 	FAC_CITY: 100,
 	FAC_PORT: 50,
@@ -84,6 +91,13 @@ const FACILITY_CAN_BUILD_FUNC = {
 }
 
 class FacilityFunctions:
+	func can_build(type, planet_data, node) -> bool:
+		return self.call(FACILITY_CAN_BUILD_FUNC[type], planet_data, node)
+		
+	func calc_range(type, planet_data, node) -> bool:
+		return self.call(FACILITY_RADIUS_FUNC[type], planet_data, node, FACILITY_RADIUS[type])
+	
+	
 	func can_build_land(planet_data, node) -> bool:
 		return not planet_data.get_node(node).is_water
 
@@ -99,3 +113,8 @@ class FacilityFunctions:
 				return true
 		
 		return false
+	
+	
+	func constant_range(_planet_data, _node, radius) -> int:
+		return radius
+

--- a/scripts/constants/facilities.gd
+++ b/scripts/constants/facilities.gd
@@ -44,7 +44,7 @@ const FACILITY_RADIUS = {
 const FACILITY_RADIUS_FUNC = {
 	FAC_CITY: "constant_range",
 	FAC_PORT: "constant_range",
-	FAC_AIR_DEFENSE: "constant_range",
+	FAC_AIR_DEFENSE: "air_defense_range",
 #	FAC_MISSILE_BASE: "constant_range",
 }
 
@@ -117,4 +117,10 @@ class FacilityFunctions:
 	
 	func constant_range(_planet_data, _node, radius) -> int:
 		return radius
+	
+	
+	func air_defense_range(planet_data, node, radius) -> int:
+		var nd = planet_data.get_node(node)
+		var ele = max(nd.elevation, 0)
+		return int(floor(float(radius) * (1.0 + ele)))
 

--- a/scripts/constants/facilities.gd
+++ b/scripts/constants/facilities.gd
@@ -75,3 +75,27 @@ const FACILITY_KEYS = {
 	FAC_AIR_DEFENSE: KEY_A,
 #	FAC_MISSILE_BASE: KEY_M,
 }
+
+const FACILITY_CAN_BUILD_FUNC = {
+	FAC_CITY: "can_build_land",
+	FAC_PORT: "can_build_port",
+	FAC_AIR_DEFENSE: "can_build_land",
+#	FAC_MISSILE_BASE: KEY_M,
+}
+
+class FacilityFunctions:
+	func can_build_land(planet_data, node) -> bool:
+		return not planet_data.get_node(node).is_water
+
+	func can_build_port(planet_data, node) -> bool:
+		var nd = planet_data.get_node(node)
+		
+		if not nd.is_water:
+			return false
+		
+		var neigh = planet_data.get_neighbors(node)
+		for n in neigh:
+			if not planet_data.get_node(n).is_water:
+				return true
+		
+		return false

--- a/scripts/gui/controls/land_use_info.gd
+++ b/scripts/gui/controls/land_use_info.gd
@@ -2,6 +2,7 @@ extends Control
 class_name LandUseInfo
 
 onready var land_use_label: Label = find_node("LandUse")
+onready var elevation_label: Label = find_node("Elevation")
 onready var resources_label: Label = find_node("Resources")
 onready var container: Container = find_node("Entries")
 
@@ -16,9 +17,15 @@ func update_info(planet: Planet, consts: LandUse, node: int):
 	if node < 0:
 		land_use_label.text = "Space"
 		resources_label.text = ""
+		elevation_label.text = ""
 		return
 	
-	var veg = planet.planet_data.get_node(node).vegetation_type
+	var nd = planet.planet_data.get_node(node)
+	var ele = Consts.elevation(nd.elevation, planet.planet_data.get_max_elevation())
+	
+	elevation_label.text = "%+dm" % ele
+	
+	var veg = nd.vegetation_type
 	var res_here = planet.resources.resources.get(node, null)
 	
 	land_use_label.text = LandUse.VEG_NAMES[veg]

--- a/scripts/gui/states/build.gd
+++ b/scripts/gui/states/build.gd
@@ -105,7 +105,11 @@ func on_planet_hovered(node: int):
 	var curr_tool = get_facility_tool()
 	var road_tool = get_road_tool()
 	if curr_tool != null:
-		radius = Facilities.FacilityFunctions.new().calc_range(curr_tool, fsm.planet.planet_data, node)
+		if node < 0:
+			radius = 0
+		else:
+			radius = Facilities.FacilityFunctions.new().calc_range(curr_tool, fsm.planet.planet_data, node)
+		
 		_update_range(node)
 		fsm.update_build_info(curr_tool, -1)
 	elif road_tool != null:
@@ -179,8 +183,12 @@ func _on_tool_changed(_button):
 	var road_tool = get_road_tool()
 	if curr_tool != null:
 		road_start_point = -1
+		var node = fsm.get_current_node()
+		if node < 0:
+			radius = 0
+		else:
+			radius = Facilities.FacilityFunctions.new().calc_range(curr_tool, fsm.planet.planet_data, node)
 		
-		radius = Facilities.FacilityFunctions.new().calc_range(curr_tool, fsm.planet.planet_data, fsm.get_current_node())
 		fsm.planet.clear_path()
 		_update_range(fsm.get_current_node())
 		indicator.visible = true

--- a/scripts/gui/states/build.gd
+++ b/scripts/gui/states/build.gd
@@ -12,6 +12,8 @@ var radius: int = 0
 
 var road_start_point: int = -1
 
+var facility_functions: Facilities.FacilityFunctions = Facilities.FacilityFunctions.new()
+
 func _ready():
 	var build_buttons: Container = find_node("BuildButtons")
 	var road_buttons: Container = find_node("RoadButtons")
@@ -103,6 +105,7 @@ func on_planet_hovered(node: int):
 	var curr_tool = get_facility_tool()
 	var road_tool = get_road_tool()
 	if curr_tool != null:
+		radius = Facilities.FacilityFunctions.new().calc_range(curr_tool, fsm.planet.planet_data, node)
 		_update_range(node)
 		fsm.update_build_info(curr_tool, -1)
 	elif road_tool != null:
@@ -177,7 +180,7 @@ func _on_tool_changed(_button):
 	if curr_tool != null:
 		road_start_point = -1
 		
-		radius = Facilities.FACILITY_RADIUS[curr_tool]
+		radius = Facilities.FacilityFunctions.new().calc_range(curr_tool, fsm.planet.planet_data, fsm.get_current_node())
 		fsm.planet.clear_path()
 		_update_range(fsm.get_current_node())
 		indicator.visible = true

--- a/scripts/managers/build_manager.gd
+++ b/scripts/managers/build_manager.gd
@@ -3,6 +3,7 @@ class_name BuildManager
 const ROAD_CAPACITY = 25
 
 var constants: LandUse
+var facility_functions: Facilities.FacilityFunctions = Facilities.FacilityFunctions.new()
 
 var network: RoadNetwork
 var resources: ResourceManager
@@ -88,10 +89,10 @@ func add_facility(type: String, location: int, name: String):
 	if costs > taxes.budget:
 		return [null, "Not enough money (requires %d)" % costs]
 	
-	var facility: Facility = load(Facilities.FACILITY_SCENES[type]).instance()
-	if not facility.can_build(planet_data, location):
-		facility.queue_free()
+	if not facility_functions.call(Facilities.FACILITY_CAN_BUILD_FUNC[type], planet_data, location):
 		return [null, "Can't build this facility here"]
+	
+	var facility: Facility = load(Facilities.FACILITY_SCENES[type]).instance()
 	
 	facility.init(location, planet_data, type)
 	

--- a/scripts/managers/build_manager.gd
+++ b/scripts/managers/build_manager.gd
@@ -89,7 +89,7 @@ func add_facility(type: String, location: int, name: String):
 	if costs > taxes.budget:
 		return [null, "Not enough money (requires %d)" % costs]
 	
-	if not facility_functions.call(Facilities.FACILITY_CAN_BUILD_FUNC[type], planet_data, location):
+	if not facility_functions.can_build(type, planet_data, location):
 		return [null, "Can't build this facility here"]
 	
 	var facility: Facility = load(Facilities.FACILITY_SCENES[type]).instance()

--- a/scripts/objects/air_defense.gd
+++ b/scripts/objects/air_defense.gd
@@ -14,8 +14,6 @@ func _ready():
 		AirAttack: 0.75,
 	}
 	
-	radius = Facilities.FACILITY_RADIUS[type]
-	
 	if randf() < 0.5:
 		anim_player.play(animation)
 	else:
@@ -28,6 +26,8 @@ func _ready():
 
 
 func on_ready(planet_data):
+	radius = Facilities.FacilityFunctions.new().calc_range(type, planet_data, node_id)
+	
 	var temp_cells = planet_data.get_in_radius(node_id, radius)
 	for c in temp_cells:
 		cells[c[0]] = c[1]

--- a/scripts/objects/air_defense.gd
+++ b/scripts/objects/air_defense.gd
@@ -53,9 +53,5 @@ func calc_is_supplied():
 			anim_player.stop(false)
 
 
-func can_build(planet_data, node) -> bool:
-	return not planet_data.get_node(node).is_water
-
-
 func _draw_cells(planet_data): 
 	range_indicator.draw_range(planet_data, node_id, cells, radius, Color.magenta)

--- a/scripts/objects/city.gd
+++ b/scripts/objects/city.gd
@@ -107,10 +107,6 @@ func read(dict: Dictionary):
 		growth_stats.space_factor = growth["space"]
 
 
-func can_build(planet_data, node) -> bool:
-	return not planet_data.get_node(node).is_water
-
-
 func has_landuse_requirements(lu: int) -> bool:
 	for req in LandUse.LU_REQUIREMENTS[lu]:
 		var found = false

--- a/scripts/objects/facility.gd
+++ b/scripts/objects/facility.gd
@@ -105,11 +105,6 @@ func get_missing_supply() -> Dictionary:
 	return res
 
 
-# warning-ignore:unused_argument
-# warning-ignore:unused_argument
-func can_build(planet_data, node) -> bool:
-	return false
-
 func add_source(commodity: String, amount: int):
 	if commodity in sources:
 		sources[commodity] += amount


### PR DESCRIPTION
Make defense ranges elevation-dependent to give mountains more meaning.

Further, display elevation in land use info panel.

Fixes #182.