### PR TITLE
Rust roads pathfinding

### DIFF
--- a/scripts/managers/city_manager.gd
+++ b/scripts/managers/city_manager.gd
@@ -76,7 +76,6 @@ func pre_update_city(city: City):
 				continue
 		
 		if veg_data.source != null:
-			# TODO: extract resources only if they are really used!
 			var amount = veg_data.source.amount if extract_resource == null \
 							else planet.resources.can_extract_resource(node, extract_resource, veg_data.source.amount)
 			if amount != 0:
@@ -188,10 +187,10 @@ func mirgate_inhabitant(from: City, attractiveness: Dictionary):
 	
 	for city in attractiveness:
 		var attr = attractiveness[city]
-		# TODO: make dependent on existing network path between cities
 		if city != from and attr > curr_attr and attr > max_attr:
-			max_attr = attr
-			max_city = city
+			if planet.roads.path_exists(from.node_id, city.node_id):
+				max_attr = attr
+				max_city = city
 	
 	if max_city != null:
 		from.remove_workers(1)

--- a/scripts/managers/road_network.gd
+++ b/scripts/managers/road_network.gd
@@ -112,6 +112,18 @@ func points_connected(v1: int, v2: int) -> bool:
 	return network.points_connected(v1, v2)
 
 
+func get_id_path(v1: int, v2: int):
+	return network.get_id_path(v1, v2)
+
+
+func path_exists(v1: int, v2: int):
+	if network.is_road(v1) and network.is_road(v1):
+		var path = network.get_id_path(v1, v2)
+		if not path.empty():
+			return true
+	return false
+
+
 func get_edge(key: Array):
 	return network.get_edge(key)
 


### PR DESCRIPTION
Add pathfinding, use it to check city connectivity for migration.

Fixes #98 