### PR TITLE
Bugfix crash road tool, build on sea lines

### DIFF
--- a/scripts/constants/network.gd
+++ b/scripts/constants/network.gd
@@ -13,7 +13,7 @@ const M_RAIL: int = 1
 const M_ELECTRIC: int = 2
 const M_SEA: int = 3
 
-const ALL_MODES: Array = [M_ROADS, M_RAIL, M_ELECTRIC]
+const ALL_MODES: Array = [M_ROADS, M_RAIL, M_ELECTRIC, M_SEA]
 
 const MODE_NAV = {
 	M_ROADS: NAV_LAND,

--- a/scripts/gui/states/build.gd
+++ b/scripts/gui/states/build.gd
@@ -107,6 +107,9 @@ func on_planet_exited():
 	fsm.update_facility_info(fsm.get_current_node())
 
 func on_planet_hovered(node: int):
+	if node < 0:
+		return
+	
 	var curr_tool = get_facility_tool()
 	var road_tool = get_road_tool()
 	if curr_tool != null:


### PR DESCRIPTION
* Prevent crash when selecting road tool and not hovering planet
* Fix missing check if tile is blocked ba sea line